### PR TITLE
Fixed build core dependency for mks_robin_nano

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -486,6 +486,7 @@ lib_ignore    = Adafruit NeoPixel, SPI
 [env:mks_robin_nano]
 platform      = ststm32
 board         = genericSTM32F103VE
+board_build.core = maple
 platform_packages = tool-stm32duino
 build_flags   = !python Marlin/src/HAL/STM32F1/build_flags.py
   ${common.build_flags} -std=gnu++14 -DHAVE_SW_SERIAL -DSS_TIMER=4


### PR DESCRIPTION
Исправления в зависимостях (только для MKS Robin Nano, по хорошему наверное надо для всех STM32-плат) для новых версий PlatformIO. Описание проблемы и решение тут: https://community.platformio.org/t/include-path-issues-include-libmaple-gpio-h/14596/4