### PR TITLE
Update Configuration.h

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1338,7 +1338,7 @@
 #endif
 
 #ifdef FB_5_STOCK
-#if MOTHERBOARD == BOARD_MKS_ROBIN_NANO_S_V13
+#if MOTHERBOARD == BOARD_MKS_ROBIN_NANO_V1_3_F4
 #define USR_E0_DIR false
 #define USR_X_DIR true
 #define USR_Y_DIR true


### PR DESCRIPTION
corrected motherboard name in FB_5_STOCK check for nano F4 to match new code

### Description

fixed board name from experimental support to official Marlin

### Requirements

BOARD_MKS_ROBIN_NANO_V1_3_F4

### Benefits

fixes axis direction

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
